### PR TITLE
Make it build with gccgo by not using the assembly versions

### DIFF
--- a/aes_gcm.go
+++ b/aes_gcm.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build amd64
+// +build gc
 
 package aes12
 

--- a/asm_amd64.s
+++ b/asm_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 #include "textflag.h"
 
 // func hasAsm() bool

--- a/cipher_amd64.go
+++ b/cipher_amd64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 package aes12
 
 // defined in asm_amd64.s

--- a/cipher_generic.go
+++ b/cipher_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64,!s390x
+// +build !amd64,!s390x !gc
 
 package aes12
 

--- a/gcm_amd64.s
+++ b/gcm_amd64.s
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build gc
+
 // This is an optimized implementation of AES-GCM using AES-NI and CLMUL-NI
 // The implementation uses some optimization as described in:
 // [1] Gueron, S., Kounavis, M.E.: Intel® Carry-Less Multiplication


### PR DESCRIPTION
Hi,

I'm on 64-bit Arch Linux.

aes12 fails to build with GCC-go and gives the following error:

```
vendor/github.com/lucas-clemente/aes12/asm_amd64.s:5:10: fatal error: textflag.h: No such file or directory
 #include "textflag.h"
          ^~~~~~~~~~~~
compilation terminated.
```

* go version: `go version go1.8.1 gccgo (GCC) 7.2.0 linux/amd64`

This merge request only adds `// +build !gccgo` directives to some of the source files.

Cheers,
Alexander F Rødseth