### PR TITLE
Revert "Modify build directives to make it build with gccgo (#4)"

### DIFF
--- a/aes_gcm.go
+++ b/aes_gcm.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 // +build amd64
-// +build gc
 
 package aes12
 

--- a/asm_amd64.s
+++ b/asm_amd64.s
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build gc
-
 #include "textflag.h"
 
 // func hasAsm() bool

--- a/cipher_amd64.go
+++ b/cipher_amd64.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build gc
-
 package aes12
 
 // defined in asm_amd64.s

--- a/cipher_generic.go
+++ b/cipher_generic.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64,!gc
+// +build !amd64
 
 package aes12
 

--- a/gcm_amd64.s
+++ b/gcm_amd64.s
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build gc
-
 // This is an optimized implementation of AES-GCM using AES-NI and CLMUL-NI
 // The implementation uses some optimization as described in:
 // [1] Gueron, S., Kounavis, M.E.: Intel® Carry-Less Multiplication


### PR DESCRIPTION
This reverts commit a427af29fdf8d54296d9726ab4384c39cfe288bb.

This commit broke our CI builds on i386.